### PR TITLE
Focus outline refactor

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixes
 - Uses `outline` for link focus styling, rather than `box-shadow`
 - Uses `outline` for button focus styling, rather than `box-shadow`
+- Uses `outline` for input focus styling, rather than `box-shadow`
 
 
 ## [6.3.16] - 2022-12-30

--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,15 @@ All notable changes to this project will be documented in this file. The format 
 ----------
 
 
+## [6.3.17] - 2023-03-17
+
+### Changes
+- Gives links their own SCSS file
+
+### Fixes
+- Uses `outline` for link focus styling, rather than `box-shadow`
+
+
 ## [6.3.16] - 2022-12-30
 
 ### Fixes

--- a/.changelog
+++ b/.changelog
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixes
 - Uses `outline` for link focus styling, rather than `box-shadow`
+- Uses `outline` for button focus styling, rather than `box-shadow`
 
 
 ## [6.3.16] - 2022-12-30

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.4.2",
+  "version": "6.3.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.4.2",
+  "version": "6.3.17",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/scss/admin/mixins/_buttons.scss
+++ b/src/scss/admin/mixins/_buttons.scss
@@ -2,6 +2,7 @@
   background-color: $colour-primary;
   border-radius: $border-radius-default;
   border: none;
+  border-bottom: solid 3px $colour-primary-dark;
   color: $colour-white;
   display: inline-block; // Older browsers
   display: inline-flex;
@@ -12,9 +13,8 @@
   padding: .5em 1em; // Older browsers
   padding: calc(.5em + 3px) 1em .5em;
   width: auto;
-  box-shadow: 0 3px $colour-primary-dark;
   @include dark-mode($colour: $colour-dark-mode-main) {
-    box-shadow: 0 3px $colour-dark-mode-primary-dark;
+    border-bottom: solid 3px $colour-dark-mode-primary-dark;
   }
   @include high-contrast($colour-dark-mode-primary-light, $colour-high-contrast-main);
 
@@ -28,24 +28,23 @@
   }
 
   &:focus {
-    outline: none;
-    box-shadow: 0 3px $colour-primary-dark, 0 3px 0 3px $colour-black, 0 0 0 3px $colour-black;
+    outline: 3px solid $colour-black;
     @include dark-mode() {
-      box-shadow: 0 3px $colour-dark-mode-primary-dark, 0 3px 0 3px $colour-white, 0 0 0 3px $colour-white;
+      outline: 3px solid $colour-white;
     }
   }
 
   &:focus:not(:focus-visible) {
-    box-shadow: 0 3px $colour-primary-dark;
+    outline: none;
     @include dark-mode() {
-      box-shadow: 0 3px $colour-dark-mode-primary-dark;
+      outline: none;
     }
   }
 
   &:focus-visible {
-    box-shadow: 0 3px $colour-primary-dark, 0 3px 0 3px $colour-black, 0 0 0 3px $colour-black;
+    outline: 3px solid $colour-black;
     @include dark-mode() {
-      box-shadow: 0 3px $colour-dark-mode-primary-dark, 0 3px 0 3px $colour-white, 0 0 0 3px $colour-white;
+      outline: 3px solid $colour-white;
     }
   }
 
@@ -57,10 +56,9 @@
 
   &:active {
     position: relative;
-    top: 2px;
-  }
-
-  &:active:active { // Chained to override non-focus box-shadow
-    box-shadow: none;
+    top: 3px;
+    border-bottom: none;
+    margin-bottom: 3px;
+    // border-top: solid 2px transparent;
   }
 }

--- a/src/scss/admin/mixins/_general.scss
+++ b/src/scss/admin/mixins/_general.scss
@@ -60,65 +60,6 @@
   }
 }
 
-@mixin text-link {
-  border-radius: $border-radius-small;
-
-  &:link,
-  &:visited {
-    color: $colour-primary-darker;
-    @include dark-mode($colour: $colour-primary);
-    @include high-contrast($colour: $colour-dark-mode-primary-light);
-  }
-
-  &:hover {
-    color: $colour-primary-dark;
-    @include dark-mode($colour: $colour-dark-mode-primary-light);
-    @include high-contrast($colour: $colour-high-contrast-primary-light);
-  }
-
-  &:active {
-    color: $colour-black;
-    @include dark-mode($colour: $colour-dark-mode-white);
-  }
-
-  &:focus {
-    outline: none;
-    background-color: $colour-white;
-    box-shadow: 0 0 0 1px $colour-white, 0 0 0 4px $colour-black;
-    box-decoration-break: clone;
-    @include dark-mode($background: $colour-dark-mode-main) {
-      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
-    }
-    @include high-contrast($background: $colour-high-contrast-main) {
-      box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
-    }
-  }
-
-  &:focus:not(:focus-visible) {
-    background-color: transparent;
-    box-shadow: none;
-    box-decoration-break: slice;
-    @include dark-mode($background: transparent) {
-      box-shadow: none;
-    }
-    @include high-contrast($background: transparent) {
-      box-shadow: none;
-    }
-  }
-
-  &:focus-visible {
-    background-color: $colour-white;
-    box-shadow: 0 0 0 1px $colour-white, 0 0 0 4px $colour-black;
-    box-decoration-break: clone;
-    @include dark-mode($background: $colour-dark-mode-main) {
-      box-shadow: 0 0 0 1px $colour-dark-mode-main, 0 0 0 4px $colour-white;
-    }
-    @include high-contrast($background: $colour-high-contrast-main) {
-      box-shadow: 0 0 0 1px $colour-high-contrast-main, 0 0 0 4px $colour-white;
-    }
-  }
-}
-
 @mixin highlight-box {
   background-color: $colour-highlight;
   @include dark-mode($background: $colour-dark-mode-highlight);

--- a/src/scss/admin/mixins/_links.scss
+++ b/src/scss/admin/mixins/_links.scss
@@ -1,0 +1,63 @@
+@mixin text-link {
+  border-radius: $border-radius-small;
+
+  &:link,
+  &:visited {
+    color: $colour-primary-darker;
+    @include dark-mode($colour: $colour-primary);
+    @include high-contrast($colour: $colour-dark-mode-primary-light);
+  }
+
+  &:hover {
+    color: $colour-primary-dark;
+    @include dark-mode($colour: $colour-dark-mode-primary-light);
+    @include high-contrast($colour: $colour-high-contrast-primary-light);
+  }
+
+  &:active {
+    color: $colour-black;
+    @include dark-mode($colour: $colour-dark-mode-white);
+  }
+
+  &:focus {
+    background-color: $colour-white;
+    outline: 3px solid $colour-black;
+    outline-offset: 1px;
+    box-decoration-break: clone;
+    @include dark-mode($background: $colour-dark-mode-main) {
+      outline: 3px solid $colour-white;
+      outline-offset: 1px;
+    }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      outline: 3px solid $colour-white;
+      outline-offset: 1px;
+    }
+  }
+
+  &:focus:not(:focus-visible) {
+    background-color: transparent;
+    outline: none;
+    box-decoration-break: slice;
+    @include dark-mode($background: transparent) {
+      outline: none;
+    }
+    @include high-contrast($background: transparent) {
+      outline: none;
+    }
+  }
+
+  &:focus-visible {
+    background-color: $colour-white;
+    outline: 3px solid $colour-black;
+    outline-offset: 1px;
+    box-decoration-break: clone;
+    @include dark-mode($background: $colour-dark-mode-main) {
+      outline: 3px solid $colour-white;
+      outline-offset: 1px;
+    }
+    @include high-contrast($background: $colour-high-contrast-main) {
+      outline: 3px solid $colour-white;
+      outline-offset: 1px;
+    }
+  }
+}

--- a/src/scss/base/_forms.scss
+++ b/src/scss/base/_forms.scss
@@ -23,11 +23,10 @@ input {
   }
 
   &:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px $colour-black;
-
+    outline: solid 3px $colour-black;
+    outline-offset: 0px;
     @include dark-mode() {
-      box-shadow: 0 0 0 3px $colour-white;
+      outline: solid 3px $colour-white;
     }
   }
 }

--- a/src/scss/base/_reset.scss
+++ b/src/scss/base/_reset.scss
@@ -112,8 +112,3 @@ iframe {
 ::-moz-focus-inner {
   border: 0;
 }
-
-:focus,
-:focus-visible {
-  outline: 0;
-}

--- a/src/scss/critical.scss
+++ b/src/scss/critical.scss
@@ -2,6 +2,7 @@
         'admin/variables',
         'admin/mixins/general',
         'admin/mixins/typography',
+        'admin/mixins/links',
         'admin/placeholders';
 
 @import 'base/reset',

--- a/src/scss/non-critical.scss
+++ b/src/scss/non-critical.scss
@@ -2,6 +2,7 @@
         'admin/variables',
         'admin/mixins/general',
         'admin/mixins/typography',
+        'admin/mixins/links',
         'admin/mixins/buttons',
         'admin/placeholders';
 

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -1,7 +1,7 @@
 module.exports = {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "6.4.2",
+  "version": "6.3.17",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",


### PR DESCRIPTION
### Changes
- Gives links their own SCSS file

### Fixes
- Uses `outline` for link focus styling, rather than `box-shadow`
- Uses `outline` for button focus styling, rather than `box-shadow`
- Uses `outline` for input focus styling, rather than `box-shadow`
