### PR TITLE
Fixing minor missing closing quotes in example code -2024-04-23--images-as-the-first-thing-in-a-button-or-link.md

### DIFF
--- a/src/site/posts/2024-04-23--images-as-the-first-thing-in-a-button-or-link.md
+++ b/src/site/posts/2024-04-23--images-as-the-first-thing-in-a-button-or-link.md
@@ -13,7 +13,7 @@ Here's an example of some problematic code:
 
 ```html
 <button>
-    <img src="bin-icon.svg alt="Bin" />
+    <img src="bin-icon.svg" alt="Bin" />
     Delete
 </button>
 ```
@@ -66,7 +66,7 @@ Easy! We just leave the icon visually and hide it accessibly:
 
 ```html
 <button>
-    <img src="bin-icon.svg alt="" />
+    <img src="bin-icon.svg" alt="" />
     Delete
 </button>
 ```


### PR DESCRIPTION
Fix unclosed `src` property on image tag example.