### PR TITLE
Fixes RSS issues

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -14,6 +14,19 @@ All notable changes to this project will be documented in this file. The format 
 ----------
 
 
+## [6.6.4] - 2025-08-16
+
+### Fixes
+- Changed `<published>` and `<updated>` dates to RFC-3339 format (was RFC-822)
+- Fixed `<category>` elements to use `term` attribute instead of text content
+- Corrected feed `<link rel="self">` to match canonical URL
+- Added `<link rel="alternate" type="text/html">` for better reader support
+- Deduplicated `<updated>` values using bumpSeconds filter
+- Stripped `<iframe>` elements from feed content for compatibility
+- Removed non-HTML `<quote>` elements, replaced with `<q>`
+- Updates site redirects in netlify.toml to use www. prefix
+
+
 ## [6.6.3] - 2025-08-05
 
 ### Fixes

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -127,6 +127,19 @@ module.exports = eleventyConfig => {
     return yyyy + '/' + mm + '/' + dd;
   });
 
+  /* Prevent duplicate updated values in feeds */
+  eleventyConfig.addFilter("bumpSeconds", (date, seconds) => {
+    const d = new Date(date);
+    d.setSeconds(d.getSeconds() + (seconds || 0));
+    return d;
+  });
+
+  /* Strip iframes from feed; improves reader compatibility */
+  eleventyConfig.addTransform("sanitise-feed-html", (content, outputPath) => {
+    if (!outputPath || !outputPath.endsWith("/feeds/main.xml")) return content;
+    return content.replace(/<iframe\b[^>]*>.*?<\/iframe>/gis, "");
+  });
+
   // Localhost server config
   eleventyConfig.setServerOptions({
     port: 3000,

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,19 +35,31 @@
 # Internal redirects
 
 ## Redirect default Netlify subdomain to primary domain
-
 [[redirects]]
   from = "https://tempertemper.netlify.com/*"
-  to = "https://tempertemper.net/:splat"
+  to = "https://www.tempertemper.net/:splat"
   status = 301
   force = true
 
 [[redirects]]
   from = "https://tempertemper.netlify.app/*"
-  to = "https://tempertemper.net/:splat"
+  to = "https://www.tempertemper.net/:splat"
   status = 301
   force = true
 
+## Canonicalise apex to www
+[[redirects]]
+  from = "https://tempertemper.net/*"
+  to = "https://www.tempertemper.net/:splat"
+  status = 301
+  force = true
+
+## Catch any stray http apex requests
+[[redirects]]
+  from = "http://tempertemper.net/*"
+  to = "https://www.tempertemper.net/:splat"
+  status = 301
+  force = true
 
 ## Services and Skills redirects
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "tempertemper's website",
   "scripts": {
     "clear": "rm -rf dist",

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -1,7 +1,7 @@
 module.exports = {
   "title": "tempertemper",
   "company": "tempertemper Web Design Ltd",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "url": "https://www.tempertemper.net",
   "baseurl": "",
   "repo": "https://github.com/tempertemper/tempertemper-website",

--- a/src/site/feeds/atom.html
+++ b/src/site/feeds/atom.html
@@ -1,41 +1,57 @@
 ---
-permalink: feeds/main.xml
+permalink: /feeds/main.xml
+eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-    <title>{{ title }}</title>
-    <subtitle>{{ description }}</subtitle>
-    <link href="{{ site.url }}" />
-    <link rel="self" type="application/atom+xml" href="{{ site.url }}/{{ permalink }}" />
-    <id>{{ site.url }}/{{ permalink }}</id>
-    <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc822 }}</updated>
-    <rights type="html">&amp;copy; copyright 2009 to {{ "" | getCurrentYear }}, {{ site.company }}</rights>
-    <logo>{{ site.url }}/assets/img/tempertemper-feed.png</logo>
-    <icon>{{ site.url }}/assets/img/icons/favicon.png</icon>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
+  <title>{{ title }}</title>
+  <subtitle>{{ description }}</subtitle>
+
+  <link href="{{ page.url | absoluteUrl(site.url) }}" rel="self" />
+  <link href="{{ site.url }}" rel="alternate" type="text/html" />
+
+  <id>{{ page.url | absoluteUrl(site.url) }}</id>
+
+  <updated>{{ collections.post | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+
+  <rights type="html">&amp;copy; copyright 2009 to {{ "" | getCurrentYear }}, {{ site.company }}</rights>
+  <logo>{{ site.url }}/assets/img/tempertemper-feed.png</logo>
+  <icon>{{ site.url }}/assets/img/icons/favicon.png</icon>
+
+  <author>
+    <name>{{ site.author.name }}</name>
+    <email>{{ site.author.email }}</email>
+    <uri>https://mastodon.social/@tempertemper</uri>
+  </author>
+
+  {%- for post in collections.post | reverse %}
+  <entry>
+    <title>{{ post.data.title | smart | safe | replace("&nbsp;", " ") | replace("&shy;", "") }}</title>
+    <link href="{{ site.url }}{{ post.url | replace ('.html', '') }}" />
+    <id>{{ site.url }}{{ post.url | replace ('.html', '') }}</id>
+
+    {% set idx = loop.index0 %}
+    <published>{{ post.date | dateToRfc3339 }}</published>
+    <updated>{{ ((post.data.updated or post.date) | bumpSeconds(idx)) | dateToRfc3339 }}</updated>
+
     <author>
-        <name>{{ site.author.name }}</name>
-        <email>{{ site.author.email }}</email>
-        <uri>https://mastodon.social/@tempertemper</uri>
+      <name>{{ site.author.name }}</name>
+      <uri>https://mastodon.social/@tempertemper</uri>
     </author>
-    {%- for post in collections.post | reverse %}
-    <entry>
-        <title>{{ post.data.title | smart | safe | replace("&nbsp;", " ") }}</title>
-        <link href="{{ site.url }}{{ post.url | replace (".html", "") }}" />
-        <id>{{ site.url }}{{ post.url | replace (".html", "") }}</id>
-        <published>{{ post.date | dateToRfc822 }}</published>
-        <updated>{%- if post.updated %}{{ post.updated  | dateToRfc822 }}{%- else %}{{ post.date | dateToRfc822 }}{%- endif %}</updated>
-        <author>
-            <name>{{ site.author.name }}</name>
-            <uri>https://mastodon.social/@tempertemper</uri>
-        </author>
-        <summary>{{ post.data.intro | markdown | safe | striptags }}</summary>
-        {%- set postTags = post.data.tags | tagsOnPage %}
-        {%- if postTags.length > 0  %}
-        {% for category in postTags %}<category>{{ category }}</category>{% endfor %}
-        {%- endif %}
-        <content type="html" xml:lang="en"><![CDATA[
-            {{ post.templateContent | safe }}<p>The article <a rel="nofollow" href="{{ site.url }}{{ post.url | replace (".html", "") }}">{{ post.data.title | smart | safe | replace("&nbsp;", " ") }}</a> appeared first on <a rel="nofollow" href="{{ site.url }}">www.tempertemper.net</a>.</p>
-            ]]></content>
-    </entry>
-    {%- endfor %}
+
+    <summary>{{ post.data.intro | markdown | safe | striptags }}</summary>
+
+    {%- set postTags = post.data.tags | tagsOnPage %}
+    {%- if postTags and postTags.length > 0 %}
+      {%- for category in postTags %}
+        <category term="{{ category }}" />
+      {%- endfor %}
+    {%- endif %}
+
+    <content type="html" xml:lang="en"><![CDATA[
+      {{ post.templateContent | safe }}
+      <p>The article <a rel="nofollow" href="{{ site.url }}{{ post.url | replace('.html', '') }}">{{ post.data.title | smart | safe | replace("&nbsp;", " ") | replace("&shy;", "") }}</a> appeared first on <a rel="nofollow" href="{{ site.url }}">www.tempertemper.net</a>.</p>
+    ]]></content>
+  </entry>
+  {%- endfor %}
 </feed>

--- a/src/site/feeds/json.html
+++ b/src/site/feeds/json.html
@@ -1,42 +1,40 @@
 ---
-permalink: feeds/main.json
+permalink: /feeds/main.json
+eleventyExcludeFromCollections: true
 ---
 {
   "version": "https://jsonfeed.org/version/1",
-  "title": "{{ title }}",
-  "home_page_url": "{{ site.url }}",
-  "feed_url": "{{ site.url }}/{{ permalink }}",
-  "description": "{{ description }}",
+  "title": {{ title | dump }},
+  "home_page_url": {{ site.url | dump }},
+  "feed_url": {{ (page.url | absoluteUrl(site.url)) | dump }},
+  "description": {{ description | dump }},
   "author": {
-    "name": "{{ site.author.name }}",
+    "name": {{ site.author.name | dump }},
     "url": "https://mastodon.social/@tempertemper",
-    "avatar": "{{ site.url }}/assets/img/martin-underhill-tempertemper--square-512x512.jpg"
+    "avatar": {{ (site.url ~ "/assets/img/martin-underhill-tempertemper--square-512x512.jpg") | dump }}
   },
-  "icon": "{{ site.url }}/assets/img/tempertemper-feed.png",
-  "favicon": "{{ site.url }}/assets/img/icons/favicon.png",
+  "icon": {{ (site.url ~ "/assets/img/tempertemper-feed.png") | dump }},
+  "favicon": {{ (site.url ~ "/assets/img/icons/favicon.png") | dump }},
   "items": [
   {%- for post in collections.post | reverse %}
+    {%- set idx = loop.index0 -%}
+    {%- set fullUrl = site.url ~ (post.url | replace(".html","")) -%}
+    {%- set postContent = post.templateContent -%}
+    {%- set commonContent = '<p>The article <a rel="nofollow" href="' + fullUrl + '">' + (post.data.title | smart | safe | replace("&nbsp;", " ") | replace("&shy;","")) + '</a> appeared first on <a rel="nofollow" href="' + site.url + '">www.tempertemper.net</a>.</p>\n' -%}
+    {%- set content = [postContent, commonContent] -%}
     {
-      "id": "{{ loop.revindex }}",
-      "date_published": "{{ post.date | dateToRfc822 }}",
-      {%- if post.updated %}"date_modified": "{{ post.updated | dateToRfc822 }}",{%- endif %}
-      "title": "{{ post.data.title | smart | safe | replace("&nbsp;", " ") }}",
-      "summary": "{{ post.data.intro | markdown | safe | striptags }}",
-      {%- set postTags = post.data.tags | tagsOnPage %}
-      {%- if postTags.length > 0  %}
-      "tags": [{% for category in postTags %}"{{ category }}"{% if not loop.last %},{% endif %}{% endfor %}],
-      {%- endif %}
-      "url": "{{ site.url }}{{ post.url | replace (".html", "") }}",
-      {%- set postContent = post.templateContent %}
-      {%- set commonContent = '<p>The article <a rel="nofollow" href="' + site.url + post.url | replace (".html", "") + '">' + post.data.title | smart | safe | replace("&nbsp;", " ") + '</a> appeared first on <a rel="nofollow" href="' + site.url + '">www.tempertemper.net</a>.</p>\n' %}
-      {%- set content = [postContent, commonContent] %}
-      "content_html": {{ content | join | dump | safe }}
-    }
-    {%- if loop.length >= 2 -%}
-      {%- if not loop.last -%}
-      ,
+      "id": {{ fullUrl | dump }},
+      "date_published": {{ (post.date | dateToRfc3339) | dump }},
+      "date_modified": {{ (((post.data.updated or post.date) | bumpSeconds(idx)) | dateToRfc3339) | dump }},
+      "title": {{ (post.data.title | smart | safe | replace("&nbsp;", " ") | replace("&shy;","")) | dump }},
+      "summary": {{ (post.data.intro | markdown | safe | striptags) | dump }},
+      {%- set postTags = post.data.tags | tagsOnPage -%}
+      {%- if postTags and postTags.length > 0 -%}
+      "tags": [{% for category in postTags %}{{ category | dump }}{% if not loop.last %},{% endif %}{% endfor %}],
       {%- endif -%}
-  {%- endif %}
+      "url": {{ fullUrl | dump }},
+      "content_html": {{ content | join | dump | safe }}
+    }{% if not loop.last %},{% endif %}
   {%- endfor %}
   ]
 }

--- a/src/site/posts/2023-09-20--own-your-own-content.md
+++ b/src/site/posts/2023-09-20--own-your-own-content.md
@@ -12,6 +12,6 @@ For a long time I've been conscious that Twitter owned the content we all posted
 
 I watched as people took advantage of the [longer character count](https://daringfireball.net/2017/11/twitter_280) and [threaded Tweets](https://www.vox.com/culture/2017/12/15/16771922/twitter-new-threading-feature) to post much longer-form thoughts directly to Twitter, glad that any content I produced that was worth anything lived safely on my own website.
 
-I won't be using it again, but I have no intention of deleting my Twitter profile or any tweets: I'm not about to break any links to my tweets (after all, [<quote>Cool URIs don't change</quote>](https://www.w3.org/Provider/Style/URI)); I'll leave that to Twitter.
+I won't be using it again, but I have no intention of deleting my Twitter profile or any tweets: I'm not about to break any links to my tweets (after all, [<q>Cool URIs don't change</q>](https://www.w3.org/Provider/Style/URI)); I'll leave that to Twitter.
 
 Meanwhile, I've downloaded an archive of my tweets, and one day I might get round to publishing them on a subdomain of my own site for posterity. I guess in theory Twitter could ask me to take them down but I'm a very small fish and, sadly, I doubt they've got the staff.


### PR DESCRIPTION
- Changes `<published>` and `<updated>` dates to RFC-3339 format (was RFC-822)
- Fixes `<category>` elements to use `term` attribute instead of text content
- Corrects feed `<link rel="self">` to match canonical URL
- Added `<link rel="alternate" type="text/html">` for better reader support
- Deduplicates `<updated>` values using bumpSeconds filter
- Strips `<iframe>` elements from feed content for compatibility
- Removes non-HTML `<quote>` elements, replaced with `<q>`
- Updates site redirects in netlify.toml to use www. prefix


Thanks to Axel at https://axel.leroy.sh for flagging the issue 🙇‍♂️