### PR TITLE
Improves site search performance

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -11,9 +11,19 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
-- Adds Natter presentation image back in on Talks page
 
 ----------
+
+
+## [6.15.5] - 2026-07-29
+
+### Changes
+- Removes Pagefind prefetching from pages other than Search
+- Adds caching for Pagefind metadata and index files
+
+### Fixes
+- Speeds up site search by removing duplicate Pagefind loading and a redundant index availability request
+- Uses Pagefind's prepared matches and excerpts instead of reprocessing every matching article
 
 
 ## [6.15.4] - 2026-07-27

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,6 +30,21 @@
 
 ## Search stuff
 [[headers]]
+  for = "/pagefind/pagefind-entry.json"
+  [headers.values]
+  Cache-Control = "public, max-age=300"
+
+[[headers]]
+  for = "/pagefind/*.pf_meta"
+  [headers.values]
+  Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+  for = "/pagefind/*.pf_index"
+  [headers.values]
+  Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
   for = "/pagefind/index/*"
   [headers.values]
   Cache-Control = "public, max-age=31536000, immutable"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tempertemper",
-  "version": "6.15.4",
+  "version": "6.15.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tempertemper",
-      "version": "6.15.4",
+      "version": "6.15.5",
       "license": "ISC",
       "devDependencies": {
         "@11ty/eleventy": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tempertemper",
-  "version": "6.15.4",
+  "version": "6.15.5",
   "description": "tempertemper's website",
   "type": "module",
   "scripts": {

--- a/src/site/_includes/head.html
+++ b/src/site/_includes/head.html
@@ -128,14 +128,9 @@
 
     {%- if page.url.startsWith('/search') -%}
         <link rel="preload" href="/pagefind/pagefind.js" as="script" crossorigin="anonymous">
-        <script src="/pagefind/pagefind.js" defer></script>
-        {%- set hint = 'preload' -%}
-    {%- else -%}
-        <link rel="prefetch" href="/pagefind/pagefind.js" as="script" crossorigin="anonymous">
-        {%- set hint = 'prefetch' -%}
+        <link rel="preload" href="/pagefind/pagefind-entry.json" as="fetch" type="application/json" crossorigin="anonymous">
+        <link rel="preload" href="/pagefind/wasm.en.pagefind" as="fetch" type="application/wasm" crossorigin="anonymous">
     {%- endif -%}
-    <link rel="{{ hint }}" href="/pagefind/pagefind-entry.json" as="fetch" type="application/json" crossorigin="anonymous">
-    <link rel="{{ hint }}" href="/pagefind/wasm.en.pagefind" as="fetch" type="application/wasm" crossorigin="anonymous">
 
     {%- set css %}
         {%- include "critical.css" %}

--- a/src/site/search.html
+++ b/src/site/search.html
@@ -6,8 +6,6 @@ layout: default
 permalink: search.html
 ---
 
-<script src="/pagefind/pagefind.js" type="text/javascript"></script>
-
 <form id="search-form" role="search">
     <div class="input-group">
         <label class="visually-hidden" for="search">Enter search term</label>
@@ -35,11 +33,6 @@ permalink: search.html
     let ranInitial = false;
 
     // Helpers
-    const normalise = (s) =>
-        (s || "")
-            .toLowerCase()
-            .normalize("NFKD")
-            .replace(/[^\p{L}\p{N}_]+/gu, "");
     const escapeHTML = (s) =>
         (s || "").replace(
             /[&<>"']/g,
@@ -84,19 +77,6 @@ permalink: search.html
         return escapeHTML(content.slice(start, start + len));
     };
 
-    // Check index exists
-    try {
-        const ok = await fetch(bp + "pagefind-entry.json", {
-            method: "HEAD",
-            cache: "no-store",
-        }).then((r) => r.ok);
-        if (!ok) throw new Error("Missing " + bp + "pagefind-entry.json");
-    } catch (e) {
-        statusEl.textContent = "Search unavailable.";
-        console.error(e);
-        throw e;
-    }
-
     // Load Pagefind
     let pagefind;
     try {
@@ -110,7 +90,10 @@ permalink: search.html
 
     // Warm WASM
     if ("requestIdleCallback" in window)
-        requestIdleCallback(() => pagefind.search("\uE000"), { timeout: 2000 });
+        requestIdleCallback(
+            () => pagefind.search("\uE000").catch(() => {}),
+            { timeout: 2000 }
+        );
     else setTimeout(() => pagefind.search("\uE000").catch(() => {}), 0);
 
     // Core search function
@@ -140,13 +123,6 @@ permalink: search.html
             return;
         }
 
-        const normQ = normalise(query);
-        const safeQuery = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const contentRe = !/[^\w]/u.test(query)
-            ? new RegExp(`\\b${safeQuery}\\w*`, "iu")
-            : new RegExp(safeQuery, "iu");
-        const urlRe = new RegExp(safeQuery, "iu");
-
         // Fetch all data in parallel
         const dataArray = await Promise.all(
             searchResults.results.map((r) => r.data())
@@ -155,27 +131,19 @@ permalink: search.html
         // Build HTML in one shot
         const itemsHtml = dataArray
             .map((data) => {
-                const matches =
-                    contentRe.test(data.meta?.title || "") ||
-                    urlRe.test(data.url || "") ||
-                    contentRe.test(data.content || "") ||
-                    normalise(data.meta?.title).includes(normQ) ||
-                    normalise(data.content).includes(normQ);
-                if (!matches) return "";
-
                 const ex = cleanExcerpt(
-                    fallbackExcerpt(data.content, query, 180)
+                    data.excerpt ||
+                        fallbackExcerpt(data.content, query, 180)
                 );
                 return `<li>
                 <h2><a href="${data.url.replace(/\.html$/, "")}">${data.meta?.title || data.url}</a></h2>
                 ${ex ? `<p>${addEllipses(ex)}</p>` : ""}
                 </li>`;
             })
-            .filter(Boolean)
             .join("");
 
         resultsEl.innerHTML = `<ul class='index-list'>${itemsHtml}</ul>`;
-        const items = document.querySelectorAll(".index-list li").length;
+        const items = dataArray.length;
         statusEl.textContent = items
             ? `${items} result${items > 1 ? "s" : ""} for “${query}”.`
             : `No results for “${query}”.`;


### PR DESCRIPTION
### Changes
- Removes Pagefind prefetching from pages other than Search
- Adds caching for Pagefind metadata and index files

### Fixes
- Speeds up site search by removing duplicate Pagefind loading and a redundant index availability request
- Uses Pagefind's prepared matches and excerpts instead of reprocessing every matching article
